### PR TITLE
Fix repeated use of shlibs:Depends substvar that lead to broken Depends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
-golang-petname (2.6) unreleased; urgency=medium
+golang-petname (2.6) UNRELEASED; urgency=medium
 
+  [ Dustin Kirkland ]
   * UNRELEASED
+
+  [ Michael Hudson-Doyle ]
+  * Fix repeated use of shlibs:Depends substvar that lead to broken Depends. 
 
  -- Dustin Kirkland <kirkland@ubuntu.com>  Mon, 14 Nov 2016 09:35:01 -0600
 

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Description: generate pronouncable, perhaps even memorable, pet names
 
 Package: golang-petname-dev
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${extra:Depends}
 Description: golang library for generating pronouncable, memorable, pet names
  This package provides a library for generating "pet names", consisting
  of a random combination of an adverb, adjective, and proper name.

--- a/debian/rules
+++ b/debian/rules
@@ -14,5 +14,5 @@ override_dh_install:
 
 ifeq ($(shell ls -d /usr/share/doc/golang-any-shared-dev/),/usr/share/doc/golang-any-shared-dev/)
 override_dh_gencontrol:
-	dh_gencontrol -- -V'shlibs:Depends=libgolang-petname1'
+	dh_gencontrol -- -V'extra:Depends=libgolang-petname1'
 endif


### PR DESCRIPTION
I'd fixed this before in the ubuntu packaging but you uploaded over it :( (compare https://launchpad.net/ubuntu/zesty/+source/golang-petname/+changelog with the changelog in the package).